### PR TITLE
Don't escape slash with dynamic attributes

### DIFF
--- a/ext/attribute_builder/attribute_builder.c
+++ b/ext/attribute_builder/attribute_builder.c
@@ -187,7 +187,7 @@ put_attribute(VALUE buf, VALUE attr_quote, VALUE key, VALUE value)
   gh_buf ob = GH_BUF_INIT;
 
   Check_Type(value, T_STRING);
-  if (houdini_escape_html(&ob, (const uint8_t *)RSTRING_PTR(value), RSTRING_LEN(value))) {
+  if (houdini_escape_html0(&ob, (const uint8_t *)RSTRING_PTR(value), RSTRING_LEN(value), 0)) {
     value = rb_enc_str_new(ob.ptr, ob.size, rb_utf8_encoding());
     gh_buf_free(&ob);
   }

--- a/spec/render/attribute_spec.rb
+++ b/spec/render/attribute_spec.rb
@@ -92,6 +92,11 @@ HAML
     expect(render_string(%q|%span{class: "x\"y'z"} hello|)).to eq(%Q{<span class='x&quot;y&#39;z'>hello</span>\n})
   end
 
+  it 'does not escape slash' do
+    expect(render_string(%q|%a{ href: 'http://example.com/' }|)).to eq(%Q{<a href='http://example.com/'></a>\n})
+    expect(render_string(%q|%a{ {}, href: 'http://example.com/' }|)).to eq(%Q{<a href='http://example.com/'></a>\n})
+  end
+
   it 'renders only name if value is true' do
     expect(render_string(%q|%span{foo: true, bar: 1} hello|)).to eq(%Q{<span bar='1' foo>hello</span>\n})
   end


### PR DESCRIPTION
ref: https://github.com/eagletmt/faml/pull/27

This PR fixes following inconsistent behavior.

```rb
$ cat in.haml
%a{ href: 'http://example.com' }
%a{ {}, href: 'http://example.com' }
$ bundle exec faml render in.haml
<a href='http://example.com'></a>
<a href='http:&#47;&#47;example.com'></a>
```

Since `houdini_escape_html` sets 1 as `houdini_escape_html0`'s argument `secure`, it escapes "/". 
I think `Faml::AttributeBuilder` should not escape "/". So I changed it to use `houdini_escape_html0` and set `secure` argument to 0.