### PR TITLE
Fix id ordering of object reference

### DIFF
--- a/lib/faml/attribute_compiler.rb
+++ b/lib/faml/attribute_compiler.rb
@@ -81,11 +81,13 @@ module Faml
       end
 
       codes = []
-      unless h.empty?
-        codes << h.inspect
-      end
       if object_ref
         codes << "::Faml::ObjectRef.render(#{object_ref})"
+      else
+        codes << 'nil'
+      end
+      unless h.empty?
+        codes << h.inspect
       end
       unless text.empty?
         codes << text

--- a/spec/render/attribute_spec.rb
+++ b/spec/render/attribute_spec.rb
@@ -223,5 +223,9 @@ HAML
     it 'renders id and class attribute with haml_object_ref' do
       expect(render_string('%span[Faml::TestRefStruct.new(123)] hello')).to eq("<span class='faml_test' id='faml_test_123'>hello</span>\n")
     end
+
+    it 'renders id in correct order' do
+      expect(render_string('%span#baz[Faml::TestStruct.new(123)]{id: "foo"} hello')).to eq("<span class='faml_test_struct' id='baz_foo_faml_test_struct_123'>hello</span>\n")
+    end
   end
 end


### PR DESCRIPTION
```haml
- ::Foo = Struct.new(:id)
%a{ id: 'bar' }[Foo.new(1)]
```

should be rendered as

```html
<a class='foo' id='bar_foo_1'></a>
```

Resolve #33 