### PR TITLE
Disable Faml::Helpers module by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,12 @@ is always rendered as
 
 It's equivalent to haml's "ugly" mode.
 
-### No Haml::Helpers except for preserve
-I won't provide helper methods of Haml::Helpers except for `preserve` .
-If you really need other helper methods, please open an issue.
+### No Haml::Helpers by default
+I won't provide helper methods of Haml::Helpers.
+If you really need helper methods, please open an issue.
+
+Only `preserve` helper method is supported by engine option.
+You have to set `Faml::Engine.options[:extend_helpers] = true` to use `preserve` .
 
 ### Others
 If you find other incompatibility, please report it to me :-p.

--- a/incompatibilities/spec/render/helpers_spec.md
+++ b/incompatibilities/spec/render/helpers_spec.md
@@ -1,5 +1,5 @@
 # [./spec/render/helpers_spec.rb:4](../../../spec/render/helpers_spec.rb#L4)
-## Input
+## Input (with options={:extend_helpers=>true})
 ```haml
 %span!= preserve "hello\nworld !"
 ```

--- a/lib/faml/cli.rb
+++ b/lib/faml/cli.rb
@@ -7,22 +7,25 @@ module Faml
 
     desc 'render FILE', 'Render haml template'
     option :format, type: :string, default: :html, desc: 'HTML format'
+    option :extend_helpers, type: :boolean, default: false, desc: 'Extend Faml::Helpers or not'
     def render(file)
-      code = compile_file(file, format: options[:format].to_sym)
+      code = compile_file(file, format: options[:format].to_sym, extend_helpers: options[:extend_helpers])
       puts instance_eval(code, file)
     end
 
     desc 'compile FILE', 'Compile haml template'
     option :format, type: :string, default: :html, desc: 'HTML format'
+    option :extend_helpers, type: :boolean, default: false, desc: 'Extend Faml::Helpers or not'
     def compile(file)
-      puts compile_file(file, format: options[:format].to_sym)
+      puts compile_file(file, format: options[:format].to_sym, extend_helpers: options[:extend_helpers])
     end
 
     desc 'temple FILE', 'Render temple AST'
     option :format, type: :string, default: :html, desc: 'HTML format'
+    option :extend_helpers, type: :boolean, default: false, desc: 'Extend Faml::Helpers or not'
     def temple(file)
       require 'pp'
-      pp Faml::Compiler.new(filename: file, format: options[:format].to_sym).call(parse_file(file))
+      pp Faml::Compiler.new(filename: file, format: options[:format].to_sym, extend_helpers: options[:extend_helpers]).call(parse_file(file))
     end
 
     desc 'stats FILE/DIR ...', 'Show statistics'

--- a/lib/faml/compiler.rb
+++ b/lib/faml/compiler.rb
@@ -22,6 +22,7 @@ module Faml
       preserve: DEFAULT_PRESERVE_TAGS,
       use_html_safe: false,
       filename: nil,
+      extend_helpers: false,
     )
 
     def initialize(*)
@@ -78,9 +79,12 @@ module Faml
     end
 
     def compile_root(ast)
-      [:multi, [:code, "extend ::#{helper_module.name}"]].tap do |temple|
-        compile_children(ast, temple)
+      temple = [:multi]
+      if options[:extend_helpers]
+        temple << [:code, "extend ::#{helper_module.name}"]
       end
+      compile_children(ast, temple)
+      temple
     end
 
     def helper_module

--- a/lib/faml/engine.rb
+++ b/lib/faml/engine.rb
@@ -10,6 +10,7 @@ module Faml
     define_options(
       generator: Temple::Generators::ArrayBuffer,
       filename: nil,
+      extend_helpers: false,
     )
 
     use HamlParser::Parser

--- a/spec/rails/spec/requests/faml_spec.rb
+++ b/spec/rails/spec/requests/faml_spec.rb
@@ -60,6 +60,13 @@ RSpec.describe 'Faml with Rails', type: :request do
   end
 
   describe 'preserve helper' do
+    around do |example|
+      extend_helpers = Faml::Engine.options[:extend_helpers]
+      Faml::Engine.options[:extend_helpers] = true
+      example.run
+      Faml::Engine.options[:extend_helpers] = extend_helpers
+    end
+
     it 'returns html_safe string' do
       get '/books/preserve'
       expect(response).to be_ok

--- a/spec/render/helpers_spec.rb
+++ b/spec/render/helpers_spec.rb
@@ -2,6 +2,6 @@ require 'spec_helper'
 
 RSpec.describe Faml::Helpers, type: :render do
   it 'has preserve method' do
-    expect(render_string('%span!= preserve "hello\nworld !"')).to eq("<span>hello&#x000A;world !</span>\n")
+    expect(render_string('%span!= preserve "hello\nworld !"', extend_helpers: true)).to eq("<span>hello&#x000A;world !</span>\n")
   end
 end


### PR DESCRIPTION
`Object#extend` could do harm to performance because of MRI's method
cache invalidation. If you need `preserve` method, you have to set
`Faml::Engine.options[:extend_helpers] = true` .