### PR TITLE
Fix duplicated attribute in dynamic attribute

### DIFF
--- a/incompatibilities/spec/render/attribute_spec.md
+++ b/incompatibilities/spec/render/attribute_spec.md
@@ -22,6 +22,25 @@
 # [./spec/render/attribute_spec.rb:52](../../../spec/render/attribute_spec.rb#L52)
 ## Input
 ```haml
+- h = {foo: 1, 'foo' => 2}
+%span{h}
+```
+
+## Faml, Haml
+```html
+<span foo='2'></span>
+
+```
+
+## Hamlit
+```html
+<span foo='1' foo='2'></span>
+
+```
+
+# [./spec/render/attribute_spec.rb:58](../../../spec/render/attribute_spec.rb#L58)
+## Input
+```haml
 %span{foo: "x\"y'z"}hello
 ```
 
@@ -37,7 +56,7 @@
 
 ```
 
-# [./spec/render/attribute_spec.rb:52](../../../spec/render/attribute_spec.rb#L52)
+# [./spec/render/attribute_spec.rb:58](../../../spec/render/attribute_spec.rb#L58)
 ## Input
 ```haml
 - v = "x\"y'z"
@@ -56,7 +75,7 @@
 
 ```
 
-# [./spec/render/attribute_spec.rb:52](../../../spec/render/attribute_spec.rb#L52)
+# [./spec/render/attribute_spec.rb:58](../../../spec/render/attribute_spec.rb#L58)
 ## Input
 ```haml
 - h = {foo: "x\"y'z"}
@@ -75,7 +94,7 @@
 
 ```
 
-# [./spec/render/attribute_spec.rb:69](../../../spec/render/attribute_spec.rb#L69)
+# [./spec/render/attribute_spec.rb:75](../../../spec/render/attribute_spec.rb#L75)
 ## Input (with options={:format=>:xhtml})
 ```haml
 - v = true
@@ -94,7 +113,7 @@
 
 ```
 
-# [./spec/render/attribute_spec.rb:69](../../../spec/render/attribute_spec.rb#L69)
+# [./spec/render/attribute_spec.rb:75](../../../spec/render/attribute_spec.rb#L75)
 ## Input (with options={:format=>:xhtml})
 ```haml
 - h = {foo: true}
@@ -113,7 +132,7 @@
 
 ```
 
-# [./spec/render/attribute_spec.rb:83](../../../spec/render/attribute_spec.rb#L83)
+# [./spec/render/attribute_spec.rb:89](../../../spec/render/attribute_spec.rb#L89)
 ## Input
 ```haml
 %span{b: __LINE__,
@@ -133,7 +152,7 @@
 
 ```
 
-# [./spec/render/attribute_spec.rb:90](../../../spec/render/attribute_spec.rb#L90)
+# [./spec/render/attribute_spec.rb:96](../../../spec/render/attribute_spec.rb#L96)
 ## Input
 ```haml
 %span{"foo\0bar" => "hello"}
@@ -151,7 +170,7 @@
 
 ```
 
-# [./spec/render/attribute_spec.rb:90](../../../spec/render/attribute_spec.rb#L90)
+# [./spec/render/attribute_spec.rb:96](../../../spec/render/attribute_spec.rb#L96)
 ## Input
 ```haml
 - val = "hello"
@@ -171,7 +190,7 @@
 
 ```
 
-# [./spec/render/attribute_spec.rb:90](../../../spec/render/attribute_spec.rb#L90)
+# [./spec/render/attribute_spec.rb:96](../../../spec/render/attribute_spec.rb#L96)
 ## Input
 ```haml
 - key = "foo\0bar"
@@ -193,7 +212,7 @@
 ...                               ^
 ```
 
-# [./spec/render/attribute_spec.rb:104](../../../spec/render/attribute_spec.rb#L104)
+# [./spec/render/attribute_spec.rb:110](../../../spec/render/attribute_spec.rb#L110)
 ## Input
 ```haml
 %span[Faml::TestStruct.new(123)] hello
@@ -211,7 +230,7 @@
 
 ```
 
-# [./spec/render/attribute_spec.rb:108](../../../spec/render/attribute_spec.rb#L108)
+# [./spec/render/attribute_spec.rb:114](../../../spec/render/attribute_spec.rb#L114)
 ## Input
 ```haml
 %span[Faml::TestStruct.new(123), :hello] hello
@@ -229,7 +248,7 @@
 
 ```
 
-# [./spec/render/attribute_spec.rb:112](../../../spec/render/attribute_spec.rb#L112)
+# [./spec/render/attribute_spec.rb:118](../../../spec/render/attribute_spec.rb#L118)
 ## Input
 ```haml
 %span[Faml::TestRefStruct.new(123)] hello
@@ -247,7 +266,7 @@
 
 ```
 
-# [./spec/render/attribute_spec.rb:116](../../../spec/render/attribute_spec.rb#L116)
+# [./spec/render/attribute_spec.rb:122](../../../spec/render/attribute_spec.rb#L122)
 ## Input
 ```haml
 %span#baz[Faml::TestStruct.new(123)]{id: "foo"} hello
@@ -265,7 +284,7 @@
 
 ```
 
-# [./spec/render/attribute_spec.rb:122](../../../spec/render/attribute_spec.rb#L122)
+# [./spec/render/attribute_spec.rb:128](../../../spec/render/attribute_spec.rb#L128)
 ## Input
 ```haml
 %span{foo: 1}(foo=2)
@@ -283,7 +302,7 @@
 
 ```
 
-# [./spec/render/attribute_spec.rb:122](../../../spec/render/attribute_spec.rb#L122)
+# [./spec/render/attribute_spec.rb:128](../../../spec/render/attribute_spec.rb#L128)
 ## Input
 ```haml
 %span(foo=2){foo: 1}
@@ -301,7 +320,7 @@
 
 ```
 
-# [./spec/render/attribute_spec.rb:122](../../../spec/render/attribute_spec.rb#L122)
+# [./spec/render/attribute_spec.rb:128](../../../spec/render/attribute_spec.rb#L128)
 ## Input
 ```haml
 - v = 2
@@ -320,7 +339,7 @@
 
 ```
 
-# [./spec/render/attribute_spec.rb:122](../../../spec/render/attribute_spec.rb#L122)
+# [./spec/render/attribute_spec.rb:128](../../../spec/render/attribute_spec.rb#L128)
 ## Input
 ```haml
 - v = 2
@@ -339,7 +358,7 @@
 
 ```
 
-# [./spec/render/attribute_spec.rb:122](../../../spec/render/attribute_spec.rb#L122)
+# [./spec/render/attribute_spec.rb:128](../../../spec/render/attribute_spec.rb#L128)
 ## Input
 ```haml
 - h = {foo: 1}
@@ -358,7 +377,7 @@
 
 ```
 
-# [./spec/render/attribute_spec.rb:122](../../../spec/render/attribute_spec.rb#L122)
+# [./spec/render/attribute_spec.rb:128](../../../spec/render/attribute_spec.rb#L128)
 ## Input
 ```haml
 - h = {foo: 1}
@@ -377,7 +396,7 @@
 
 ```
 
-# [./spec/render/attribute_spec.rb:141](../../../spec/render/attribute_spec.rb#L141)
+# [./spec/render/attribute_spec.rb:147](../../../spec/render/attribute_spec.rb#L147)
 ## Input
 ```haml
 %span{id: 1}(id=2)

--- a/lib/faml/attribute_optimizer.rb
+++ b/lib/faml/attribute_optimizer.rb
@@ -59,10 +59,9 @@ module Faml
       parser.dynamic_attributes.each do |k, v|
         k = k.to_s
         if static_attributes.key?(k)
-          if StaticHashParser::SPECIAL_ATTRIBUTES.include?(k)
-            # XXX: Quit optimization
-            return nil
-          end
+          # XXX: Quit optimization.
+          # See also https://github.com/eagletmt/faml/issues/44
+          return nil
         end
         dynamic_attributes[k] = v
       end

--- a/spec/render/attribute_spec.rb
+++ b/spec/render/attribute_spec.rb
@@ -49,6 +49,12 @@ RSpec.describe 'Attributes rendering', type: :render do
 HAML
   end
 
+  it 'renders duplicated keys correctly' do
+    expect(render_string("%span{foo: 1, 'foo' => 2}")).to eq("<span foo='2'></span>\n")
+    expect(render_string("- v = 2\n%span{foo: 1, 'foo' => v}")).to eq("<span foo='2'></span>\n")
+    expect(render_string("- h = {foo: 1, 'foo' => 2}\n%span{h}")).to eq("<span foo='2'></span>\n")
+  end
+
   it 'escapes' do
     with_each_attribute_type(:foo, %q|"x\"y'z"|, text: 'hello') do |str|
       expect(render_string(str)).to eq(%Q{<span foo='x&quot;y&#39;z'>hello</span>\n})


### PR DESCRIPTION
Use runtime AttributeBuilder when static attributes and dynamic
attributes have common key.

Resolve #44 