### PR TITLE
Rewrite in C++ to improve performance

### DIFF
--- a/ext/attribute_builder/attribute_builder.cc
+++ b/ext/attribute_builder/attribute_builder.cc
@@ -16,7 +16,7 @@
 # define rb_ary_new_capa rb_ary_new2
 #endif
 
-#define FOREACH_FUNC(func) ((int (*)(ANYARGS))(func))
+#define FOREACH_FUNC(func) reinterpret_cast<int (*)(ANYARGS)>(func)
 
 VALUE rb_mAttributeBuilder;
 static ID id_flatten;
@@ -155,7 +155,7 @@ normalize_data_i(VALUE key, VALUE value, VALUE normalized)
     struct normalize_data_i2_arg arg;
     arg.key = key;
     arg.normalized = normalized;
-    rb_hash_foreach(normalize_data(value), FOREACH_FUNC(normalize_data_i2), (VALUE)(&arg));
+    rb_hash_foreach(normalize_data(value), FOREACH_FUNC(normalize_data_i2), reinterpret_cast<VALUE>(&arg));
   } else if (RB_TYPE_P(value, T_TRUE) || !RTEST(value)) {
     /* Keep Qtrue and falsey value */
     rb_hash_aset(normalized, key, value);
@@ -179,7 +179,7 @@ normalize_data(VALUE data)
 static int
 put_data_attribute(VALUE key, VALUE val, VALUE arg)
 {
-  attribute_holder *attributes = (attribute_holder *)arg;
+  attribute_holder *attributes = reinterpret_cast<attribute_holder *>(arg);
   attributes->insert("data-" + std::string(RSTRING_PTR(key), RSTRING_LEN(key)), attribute_value::from_value(val));
   return ST_CONTINUE;
 }
@@ -187,7 +187,7 @@ put_data_attribute(VALUE key, VALUE val, VALUE arg)
 static int
 merge_one_i(VALUE key, VALUE value, VALUE arg)
 {
-  attribute_holder *attributes = (attribute_holder *)arg;
+  attribute_holder *attributes = reinterpret_cast<attribute_holder *>(arg);
 
   key = rb_convert_type(key, T_STRING, "String", "to_s");
   const std::string key_(RSTRING_PTR(key), RSTRING_LEN(key));
@@ -208,7 +208,7 @@ static void
 merge_one(attribute_holder& attributes, VALUE h)
 {
   Check_Type(h, T_HASH);
-  rb_hash_foreach(h, FOREACH_FUNC(merge_one_i), (VALUE)&attributes);
+  rb_hash_foreach(h, FOREACH_FUNC(merge_one_i), reinterpret_cast<VALUE>(&attributes));
 }
 
 static void

--- a/ext/attribute_builder/attribute_builder.cc
+++ b/ext/attribute_builder/attribute_builder.cc
@@ -22,6 +22,12 @@ VALUE rb_mAttributeBuilder;
 static ID id_flatten;
 static ID id_hyphen;
 
+static inline std::string
+string_from_value(VALUE v)
+{
+  return std::string(RSTRING_PTR(v), RSTRING_LEN(v));
+}
+
 enum attribute_value_type
 {
   ATTRIBUTE_TYPE_TRUE,
@@ -46,7 +52,7 @@ struct attribute_value
       return attribute_value(ATTRIBUTE_TYPE_FALSE);
     } else {
       value = rb_convert_type(value, T_STRING, "String", "to_s");
-      return attribute_value(RSTRING_PTR(value), RSTRING_LEN(value));
+      return attribute_value(string_from_value(value));
     }
   }
 };
@@ -180,7 +186,7 @@ static int
 put_data_attribute(VALUE key, VALUE val, VALUE arg)
 {
   attribute_holder *attributes = reinterpret_cast<attribute_holder *>(arg);
-  attributes->insert("data-" + std::string(RSTRING_PTR(key), RSTRING_LEN(key)), attribute_value::from_value(val));
+  attributes->insert("data-" + string_from_value(key), attribute_value::from_value(val));
   return ST_CONTINUE;
 }
 
@@ -190,7 +196,7 @@ merge_one_i(VALUE key, VALUE value, VALUE arg)
   attribute_holder *attributes = reinterpret_cast<attribute_holder *>(arg);
 
   key = rb_convert_type(key, T_STRING, "String", "to_s");
-  const std::string key_(RSTRING_PTR(key), RSTRING_LEN(key));
+  const std::string key_ = string_from_value(key);
   if (key_ == "class") {
     concat_array_attribute(attributes->classes_, value);
   } else if (key_ == "id") {
@@ -354,7 +360,7 @@ m_build(int argc, VALUE *argv, RB_UNUSED_VAR(VALUE self))
 
   rb_check_arity(argc, 3, UNLIMITED_ARGUMENTS);
   Check_Type(argv[0], T_STRING);
-  const std::string attr_quote(RSTRING_PTR(argv[0]), RSTRING_LEN(argv[0]));
+  const std::string attr_quote = string_from_value(argv[0]);
   is_html = RTEST(argv[1]);
   object_ref = argv[2];
   const attributes_type attributes = merge(object_ref, argc-3, argv+3);

--- a/ext/attribute_builder/attribute_builder.cc
+++ b/ext/attribute_builder/attribute_builder.cc
@@ -307,6 +307,7 @@ m_merge(int argc, VALUE *argv, RB_UNUSED_VAR(VALUE self))
   return merge(argv[0], argc-1, argv+1);
 }
 
+extern "C" {
 void
 Init_attribute_builder(void)
 {
@@ -336,3 +337,4 @@ Init_attribute_builder(void)
   rb_const_set(rb_mAttributeBuilder, id_space, rb_obj_freeze(rb_str_new_cstr(" ")));
   rb_const_set(rb_mAttributeBuilder, id_equal, rb_obj_freeze(rb_str_new_cstr("=")));
 }
+};

--- a/ext/attribute_builder/extconf.rb
+++ b/ext/attribute_builder/extconf.rb
@@ -2,10 +2,11 @@
 require 'mkmf'
 
 $CFLAGS << ' -Wall -W'
+$CXXFLAGS << ' -Wall -W -std=c++03'
 houdini_dir = File.expand_path('../../vendor/houdini', __dir__)
 $INCFLAGS << " -I#{houdini_dir}"
 
-$srcs = %w[attribute_builder.c]
+$srcs = %w[attribute_builder.cc]
 %w[
   buffer.c
   houdini_html_e.c


### PR DESCRIPTION
Use std::string, std::vector and std::map instead of T_STRING, T_ARRAY and T_HASH .

## Before

```
Calculating -------------------------------------
                Haml   714.000  i/100ms
        Faml (Array)     2.644k i/100ms
       Faml (String)     2.380k i/100ms
      Hamlit (Array)     1.422k i/100ms
     Hamlit (String)     1.306k i/100ms
        Slim (Array)     2.017k i/100ms
       Slim (String)     1.603k i/100ms
-------------------------------------------------
                Haml      8.017k (± 1.3%) i/s -     40.698k
        Faml (Array)     39.366k (± 3.0%) i/s -    198.300k
       Faml (String)     34.409k (± 3.4%) i/s -    173.740k
      Hamlit (Array)     18.288k (± 2.5%) i/s -     92.430k
     Hamlit (String)     17.162k (± 2.6%) i/s -     86.196k
        Slim (Array)     28.909k (± 3.1%) i/s -    145.224k
       Slim (String)     20.886k (± 2.3%) i/s -    105.798k

Comparison:
        Faml (Array):    39365.6 i/s
       Faml (String):    34408.6 i/s - 1.14x slower
        Slim (Array):    28909.3 i/s - 1.36x slower
       Slim (String):    20886.1 i/s - 1.88x slower
      Hamlit (Array):    18288.4 i/s - 2.15x slower
     Hamlit (String):    17162.3 i/s - 2.29x slower
                Haml:     8016.8 i/s - 4.91x slower
```

## After

```
Calculating -------------------------------------
                Haml   749.000  i/100ms
        Faml (Array)     3.327k i/100ms
       Faml (String)     2.794k i/100ms
      Hamlit (Array)     1.489k i/100ms
     Hamlit (String)     1.359k i/100ms
        Slim (Array)     2.084k i/100ms
       Slim (String)     1.595k i/100ms
-------------------------------------------------
                Haml      8.416k (± 1.2%) i/s -     42.693k
        Faml (Array)     53.435k (± 2.3%) i/s -    269.487k
       Faml (String)     44.437k (± 2.3%) i/s -    223.520k
      Hamlit (Array)     18.639k (± 1.6%) i/s -     93.807k
     Hamlit (String)     17.285k (± 1.7%) i/s -     86.976k
        Slim (Array)     28.898k (± 2.5%) i/s -    145.880k
       Slim (String)     21.367k (± 2.2%) i/s -    106.865k

Comparison:
        Faml (Array):    53435.2 i/s
       Faml (String):    44437.5 i/s - 1.20x slower
        Slim (Array):    28898.1 i/s - 1.85x slower
       Slim (String):    21366.7 i/s - 2.50x slower
      Hamlit (Array):    18639.3 i/s - 2.87x slower
     Hamlit (String):    17285.2 i/s - 3.09x slower
                Haml:     8416.3 i/s - 6.35x slower
```