### PR TITLE
Support Ruby 2.7

### DIFF
--- a/ext/attribute_builder/attribute_builder.cc
+++ b/ext/attribute_builder/attribute_builder.cc
@@ -13,7 +13,12 @@
 #define rb_utf8_str_new(ptr, len) rb_enc_str_new(ptr, len, rb_utf8_encoding())
 #endif
 
+/* https://github.com/ruby/ruby/commit/50f5a0a8d6e7ad89d6caff695a08dbd38edb7a6e */
+#if RUBY_API_VERSION_MAJOR == 2 && RUBY_API_VERSION_MINOR < 7
 #define FOREACH_FUNC(func) reinterpret_cast<int (*)(ANYARGS)>(func)
+#else
+#define FOREACH_FUNC(func) func
+#endif
 
 VALUE rb_mAttributeBuilder;
 static ID id_flatten;


### PR DESCRIPTION
This pull request fixes the following compilation error on Ruby master (newer than https://github.com/ruby/ruby/commit/50f5a0a8d6e7ad89d6caff695a08dbd38edb7a6e):

```
../../../../ext/attribute_builder/attribute_builder.cc: In function ‘attributes_type normalize_data(VALUE)’:
../../../../ext/attribute_builder/attribute_builder.cc:16:28: error: invalid conversion from ‘int (*)(...)’ to ‘int (*)(VALUE, VALUE, VALUE) {aka int (*)(long unsigned int, long unsigned int, long unsigned int)}’ [-fpermissive]
 #define FOREACH_FUNC(func) reinterpret_cast<int (*)(ANYARGS)>(func)
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../../ext/attribute_builder/attribute_builder.cc:130:25: note: in expansion of macro ‘FOREACH_FUNC’
   rb_hash_foreach(data, FOREACH_FUNC(normalize_data_i),
                         ^~~~~~~~~~~~
In file included from /home/k0kubun/.rbenv/versions/ruby/include/ruby-2.7.0/ruby/ruby.h:2127:0,
                 from /home/k0kubun/.rbenv/versions/ruby/include/ruby-2.7.0/ruby.h:33,
                 from ../../../../ext/attribute_builder/attribute_builder.cc:1:
/home/k0kubun/.rbenv/versions/ruby/include/ruby-2.7.0/ruby/intern.h:534:6: note:   initializing argument 2 of ‘void rb_hash_foreach(VALUE, int (*)(VALUE, VALUE, VALUE), VALUE)’
 void rb_hash_foreach(VALUE, int (*)(VALUE, VALUE, VALUE), VALUE);
      ^~~~~~~~~~~~~~~
```

ref: https://github.com/ruby/ruby/pull/2404

Caveats: This patch does not work for 2.7.0-preview1...