### PR TITLE
Fix deprecation warning on Rails 6.0 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,4 @@ gemspec
 gem 'rails'
 gem 'rspec-rails', '>= 3.2.0'
 gem 'sqlite3'
+gem 'rails-controller-testing'

--- a/lib/faml/rails_handler.rb
+++ b/lib/faml/rails_handler.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 module Faml
   class RailsHandler
-    def call(template)
+    def call(template, source = nil)
+      source ||= template.source
       Engine.new(
         use_html_safe: true,
         generator: Temple::Generators::RailsOutputBuffer,
         filename: template.identifier,
-      ).call(template.source)
+      ).call(source)
     end
   end
 end

--- a/spec/rails/app/assets/config/manifest.js
+++ b/spec/rails/app/assets/config/manifest.js
@@ -1,0 +1,3 @@
+//= link_tree ../images
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css

--- a/spec/rails/spec/requests/faml_spec.rb
+++ b/spec/rails/spec/requests/faml_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'Faml with Rails', type: :request do
     end
 
     it 'works with id' do
-      get '/books/object_ref', id: 123
+      get '/books/object_ref', params: { id: 123 }
       expect(response).to be_ok
       expect(response.body).to include("<div class='book' id='book_123'>")
     end


### PR DESCRIPTION
In Rails 6.0 the API for template handlers is changing, a template handler must now take two arguments [1], the template and the source, otherwise you will see the following deprecation warning:

```
DEPRECATION WARNING: Single arity template handlers are deprecated. Template handlers must
now accept two parameters, the view object and the source for the view object.
Change:
  >> #<Faml::RailsHandler:0x0000561d54608868>.call(template)
To:
  >> #<Faml::RailsHandler:0x0000561d54608868>.call(template, source)
```

This fixes that deprecation warning.

[1] https://www.github.com/rails/rails/commit/28f88e0074